### PR TITLE
Feat(sensors): Define explicit is_fallback field

### DIFF
--- a/services/core/devices/application.go
+++ b/services/core/devices/application.go
@@ -104,6 +104,7 @@ type NewSensorDTO struct {
 	ExternalID  string          `json:"external_id"`
 	Properties  json.RawMessage `json:"properties"`
 	ArchiveTime *int            `json:"archive_time"`
+	IsFallback  bool            `json:"is_fallback"`
 }
 
 func (s *Service) AddSensor(ctx context.Context, dev *Device, dto NewSensorDTO) error {
@@ -114,6 +115,7 @@ func (s *Service) AddSensor(ctx context.Context, dev *Device, dto NewSensorDTO) 
 		ExternalID:  dto.ExternalID,
 		Properties:  dto.Properties,
 		ArchiveTime: dto.ArchiveTime,
+		IsFallback:  dto.IsFallback,
 	}
 	if err := dev.AddSensor(opts); err != nil {
 		return err

--- a/services/core/devices/devices.go
+++ b/services/core/devices/devices.go
@@ -38,10 +38,10 @@ var (
 		"sensor with that code already exists on the device",
 		"DEVICE_DUPLICATE_SENSOR_CODE",
 	)
-	ErrDuplicateDefaultSensor = web.NewError(
+	ErrDuplicateFallbackSensor = web.NewError(
 		http.StatusConflict,
-		"a sensor on this device already has `default` set, can only have one default sensor",
-		"DEVICE_DUPLICATE_SENSOR_DEFAULT",
+		"this device already has a sensor with 'is_fallback' set, can only have one",
+		"DEVICE_DUPLICATE_FALLBACK_SENSOR",
 	)
 	ErrInvalidCoordinates = web.NewError(
 		http.StatusBadRequest,
@@ -173,7 +173,7 @@ func (d *Device) AddSensor(opts NewSensorOpts) error {
 			return ErrDuplicateSensorCode
 		}
 		if opts.IsFallback && existing.IsFallback {
-			return ErrDuplicateDefaultSensor
+			return ErrDuplicateFallbackSensor
 		}
 	}
 

--- a/services/core/devices/devices.go
+++ b/services/core/devices/devices.go
@@ -38,6 +38,11 @@ var (
 		"sensor with that code already exists on the device",
 		"DEVICE_DUPLICATE_SENSOR_CODE",
 	)
+	ErrDuplicateDefaultSensor = web.NewError(
+		http.StatusConflict,
+		"a sensor on this device already has `default` set, can only have one default sensor",
+		"DEVICE_DUPLICATE_SENSOR_DEFAULT",
+	)
 	ErrInvalidCoordinates = web.NewError(
 		http.StatusBadRequest,
 		"Invalid coordinates supplied",
@@ -75,6 +80,7 @@ type Sensor struct {
 	Brand       string          `json:"brand"`
 	ArchiveTime *int            `json:"archive_time" db:"archive_time"`
 	ExternalID  string          `json:"external_id" db:"external_id"`
+	IsFallback  bool            `json:"is_fallback" db:"is_fallback"`
 	Properties  json.RawMessage `json:"properties"`
 	CreatedAt   time.Time       `json:"created_at" db:"created_at"`
 }
@@ -131,6 +137,7 @@ type NewSensorOpts struct {
 	ExternalID  string          `json:"external_id"`
 	ArchiveTime *int            `json:"archive_time"`
 	Properties  json.RawMessage `json:"properties"`
+	IsFallback  bool            `json:"is_fallback"`
 }
 
 func NewSensor(opts NewSensorOpts) (*Sensor, error) {
@@ -141,6 +148,7 @@ func NewSensor(opts NewSensorOpts) (*Sensor, error) {
 		Properties:  []byte("{}"),
 		ArchiveTime: opts.ArchiveTime,
 		CreatedAt:   time.Now(),
+		IsFallback:  opts.IsFallback,
 	}
 
 	if !R_CODE.MatchString(opts.Code) {
@@ -163,6 +171,9 @@ func (d *Device) AddSensor(opts NewSensorOpts) error {
 		}
 		if existing.Code == opts.Code {
 			return ErrDuplicateSensorCode
+		}
+		if opts.IsFallback && existing.IsFallback {
+			return ErrDuplicateDefaultSensor
 		}
 	}
 
@@ -193,6 +204,16 @@ func (d *Device) GetSensorByCode(code string) (*Sensor, error) {
 func (d *Device) GetSensorByExternalID(eid string) (*Sensor, error) {
 	for _, sensor := range d.Sensors {
 		if sensor.ExternalID == eid {
+			return &sensor, nil
+		}
+	}
+
+	return nil, ErrSensorNotFound
+}
+
+func (d *Device) GetFallbackSensor() (*Sensor, error) {
+	for _, sensor := range d.Sensors {
+		if sensor.IsFallback {
 			return &sensor, nil
 		}
 	}

--- a/services/core/devices/devices_test.go
+++ b/services/core/devices/devices_test.go
@@ -1,0 +1,100 @@
+package devices_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"sensorbucket.nl/sensorbucket/services/core/devices"
+)
+
+func TestAddSensorToDevice(t *testing.T) {
+	setupDevice := func() *devices.Device {
+		device, err := devices.NewDevice(devices.NewDeviceOpts{
+			Code:         "testdevice",
+			Description:  "",
+			Organisation: "",
+			Properties:   json.RawMessage("{}"),
+			State:        devices.DeviceEnabled,
+		})
+		require.NoError(t, err)
+		err = device.AddSensor(devices.NewSensorOpts{
+			Code:        "existing",
+			Description: "",
+			ExternalID:  "existing",
+			Properties:  json.RawMessage("{}"),
+			IsFallback:  true,
+		})
+		require.NoError(t, err)
+		return device
+	}
+
+	testCases := []struct {
+		desc        string
+		sensor      devices.NewSensorOpts
+		expectedErr error
+	}{
+		{
+			desc: "Add single non-conflicting sensor",
+			sensor: devices.NewSensorOpts{
+				Code:        "new_sensor",
+				Brand:       "",
+				Description: "",
+				ExternalID:  "",
+				Properties:  json.RawMessage("{}"),
+				IsFallback:  false,
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "Duplicate sensor code",
+			sensor: devices.NewSensorOpts{
+				Code:        "existing",
+				Brand:       "",
+				Description: "",
+				ExternalID:  "",
+				Properties:  json.RawMessage("{}"),
+				IsFallback:  false,
+			},
+			expectedErr: devices.ErrDuplicateSensorCode,
+		},
+		{
+			desc: "Duplicate sensor external ID",
+			sensor: devices.NewSensorOpts{
+				Code:        "new_sensor",
+				Brand:       "",
+				Description: "",
+				ExternalID:  "existing",
+				Properties:  json.RawMessage("{}"),
+				IsFallback:  false,
+			},
+			expectedErr: devices.ErrDuplicateSensorExternalID,
+		},
+		{
+			desc: "Two default sensors, one device",
+			sensor: devices.NewSensorOpts{
+				Code:        "new_sensor",
+				Brand:       "",
+				Description: "",
+				ExternalID:  "new",
+				Properties:  json.RawMessage("{}"),
+				IsFallback:  true,
+			},
+			expectedErr: devices.ErrDuplicateDefaultSensor,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			device := setupDevice()
+			err := device.AddSensor(tC.sensor)
+			if tC.expectedErr != nil {
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, tC.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/services/core/devices/devices_test.go
+++ b/services/core/devices/devices_test.go
@@ -82,7 +82,7 @@ func TestAddSensorToDevice(t *testing.T) {
 				Properties:  json.RawMessage("{}"),
 				IsFallback:  true,
 			},
-			expectedErr: devices.ErrDuplicateDefaultSensor,
+			expectedErr: devices.ErrDuplicateFallbackSensor,
 		},
 	}
 	for _, tC := range testCases {

--- a/services/core/devices/infra/store_psql_test.go
+++ b/services/core/devices/infra/store_psql_test.go
@@ -150,6 +150,7 @@ func TestShouldAddSensor(t *testing.T) {
 		Description: "description",
 		Properties:  json.RawMessage("{}"),
 		ArchiveTime: ptr(1500),
+		IsFallback:  true,
 	}
 	dev := &devices.Device{
 		Code:                "test",
@@ -190,6 +191,7 @@ func TestShouldAddSensor(t *testing.T) {
 		assert.Equal(t, s1.ExternalID, dbSensor.ExternalID)
 		assert.Equal(t, s1.Properties, dbSensor.Properties)
 		assert.Equal(t, s1.ArchiveTime, dbSensor.ArchiveTime)
+		assert.Equal(t, s1.IsFallback, dbSensor.IsFallback)
 	})
 	t.Run("should delete sensor", func(t *testing.T) {
 		require.Len(t, dev.Sensors, 1)

--- a/services/core/measurements/measurements.go
+++ b/services/core/measurements/measurements.go
@@ -44,6 +44,7 @@ type Measurement struct {
 	SensorExternalID                string              `json:"sensor_external_id"`
 	SensorProperties                json.RawMessage     `json:"sensor_properties"`
 	SensorBrand                     string              `json:"sensor_brand"`
+	SensorIsFallback                bool                `json:"sensor_is_fallback"`
 	SensorArchiveTime               *int                `json:"sensor_archive_time"`
 	DatastreamID                    uuid.UUID           `json:"datastream_id"`
 	DatastreamDescription           string              `json:"datastream_description"`

--- a/services/core/migrations/20230807113939_add_sensor_field_is_fallback.up.sql
+++ b/services/core/migrations/20230807113939_add_sensor_field_is_fallback.up.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+ALTER TABLE sensors ADD "is_fallback" boolean NOT NULL DEFAULT(false);
+UPDATE sensors SET is_fallback = true WHERE sensors.external_id is null;
+
+ALTER TABLE sensors ALTER external_ID SET DEFAULT('');
+UPDATE sensors SET external_id = '' WHERE external_id is null;
+ALTER TABLE sensors ALTER external_id SET NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
Removes possible null value for external_id in db.
If a measurement is processed which has an external_id that does not match a sensor of the device, it will try to use a sensor which has is_fallback set to true. 
If a fallback sensor is used, the observation property will be prefixed with the original external_id as to avoid observation property collisions.