### PR TITLE
chore(dashboard): fix bugs found in dashboard review

### DIFF
--- a/services/dashboard/main.go
+++ b/services/dashboard/main.go
@@ -68,6 +68,7 @@ func Run(cleanup cleanupper.Cleanupper) error {
 	jwks := auth.NewJWKSHttpClient(AUTH_JWKS_URL)
 	router.Use(
 		middleware.Logger,
+		middleware.Recoverer,
 		auth.ForwardRequestAuthentication(),
 		auth.Authenticate(jwks),
 		auth.Protect(),
@@ -107,7 +108,6 @@ func Run(cleanup cleanupper.Cleanupper) error {
 	))
 	csrfWrappedHandler := nosurf.New(router)
 	csrfWrappedHandler.SetFailureHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Printf("nosurf.Reason(r): %v\n", nosurf.Reason(r))
 		layout.WithSnackbarError(w, "CSRF Token was invalid, try reloading the page")
 		//nolint
 		w.Write([]byte("A CSRF error occured. Reload the previous page and try again"))

--- a/services/dashboard/routes/ingress.go
+++ b/services/dashboard/routes/ingress.go
@@ -75,22 +75,22 @@ func (h *TracesPageHandler) listPartial() http.HandlerFunc {
 
 func formatSince(t time.Time) string {
 	d := time.Since(t)
-	if d.Hours() > 24 {
+	switch {
+	case d.Hours() > 24:
 		return "More than a day ago"
-	}
-	if int(d.Hours()) > 1 {
+	case int(d.Hours()) >= 1:
+		if int(d.Hours()) == 1 {
+			return "About 1 hour ago"
+		}
 		return fmt.Sprintf("About %d hours ago", int(d.Hours()))
-	}
-	if int(d.Hours()) > 0 {
-		return fmt.Sprintf("About %d hours ago", int(d.Hours()))
-	}
-	if int(d.Minutes()) > 1 {
+	case int(d.Minutes()) >= 1:
+		if int(d.Minutes()) == 1 {
+			return "About 1 minute ago"
+		}
 		return fmt.Sprintf("About %d minutes ago", int(d.Minutes()))
+	default:
+		return fmt.Sprintf("About %d seconds ago", int(d.Seconds()))
 	}
-	if int(d.Minutes()) > 0 {
-		return fmt.Sprintf("About %d minute ago", int(d.Minutes()))
-	}
-	return fmt.Sprintf("About %d seconds ago", int(d.Seconds()))
 }
 
 func (h *TracesPageHandler) createViewData(ctx context.Context, traces []api.Trace) ([]views.Trace, error) {
@@ -138,7 +138,7 @@ func (h *TracesPageHandler) createViewData(ctx context.Context, traces []api.Tra
 			viewModels[i].Steps = append(viewModels[i].Steps, step)
 
 			// update last worker with duration
-			if j > 0 {
+			if j > 0 && j < len(trace.WorkerTimes) {
 				viewModels[i].Steps[j-1].Label = trace.WorkerTimes[j].Sub(trace.WorkerTimes[j-1]).String()
 			}
 

--- a/services/dashboard/routes/overview.go
+++ b/services/dashboard/routes/overview.go
@@ -98,7 +98,15 @@ func (t *OverviewRoute) createSensorGroup() http.HandlerFunc {
 		w.Header().Set("hx-push-url", views.U("/overview?%s", r.URL.Query().Encode()))
 		w.Header().Set("hx-trigger-after-settle", "newDeviceList")
 		views.WriteRenderFilters(w, sg, true)
-		views.WriteRenderDeviceTable(w, res.Data, getCursor(res.Links.GetNext()))
+		nextPage := ""
+		if cursor := getCursor(res.Links.GetNext()); cursor != "" {
+			if sg != nil {
+				nextPage = views.U("/overview/devices/table?sensor_group=%d&cursor=%s", sg.GetId(), cursor)
+			} else {
+				nextPage = views.U("/overview/devices/table?cursor=%s", cursor)
+			}
+		}
+		views.WriteRenderDeviceTable(w, res.Data, nextPage)
 	}
 }
 
@@ -112,7 +120,11 @@ func (t *OverviewRoute) deleteSensorGroup() http.HandlerFunc {
 		w.Header().Set("hx-push-url", views.U("/overview?%s", r.URL.Query().Encode()))
 		w.Header().Set("hx-trigger-after-settle", "newDeviceList")
 		views.WriteRenderFilters(w, nil, true)
-		views.WriteRenderDeviceTable(w, res.Data, getCursor(res.Links.GetNext()))
+		nextPage := ""
+		if cursor := getCursor(res.Links.GetNext()); cursor != "" {
+			nextPage = views.U("/overview/devices/table?cursor=%s", cursor)
+		}
+		views.WriteRenderDeviceTable(w, res.Data, nextPage)
 	}
 }
 
@@ -137,8 +149,12 @@ func (t *OverviewRoute) getDevicesTable() http.HandlerFunc {
 		}
 
 		nextCursor := ""
-		if res.Links.GetNext() != "" {
-			nextCursor = views.U("/overview/devices/table?cursor=%s", getCursor(res.Links.GetNext()))
+		if cursor := getCursor(res.Links.GetNext()); cursor != "" {
+			if sg := r.URL.Query().Get("sensor_group"); sg != "" {
+				nextCursor = views.U("/overview/devices/table?sensor_group=%s&cursor=%s", sg, cursor)
+			} else {
+				nextCursor = views.U("/overview/devices/table?cursor=%s", cursor)
+			}
 		}
 		views.WriteRenderDeviceTableRows(w, res.Data, nextCursor)
 	}
@@ -187,10 +203,11 @@ func (t *OverviewRoute) deviceListPage() http.HandlerFunc {
 		}
 		page.Devices = res.Data
 
-		if res.Links.GetNext() != "" {
-			u, err := url.Parse(res.Links.GetNext())
-			if err == nil {
-				page.DevicesNextPage = views.U("/overview/devices/table?cursor=%s", u.Query().Get("cursor"))
+		if cursor := getCursor(res.Links.GetNext()); cursor != "" {
+			if page.SensorGroup != nil {
+				page.DevicesNextPage = views.U("/overview/devices/table?sensor_group=%d&cursor=%s", page.SensorGroup.GetId(), cursor)
+			} else {
+				page.DevicesNextPage = views.U("/overview/devices/table?cursor=%s", cursor)
 			}
 		}
 
@@ -290,12 +307,12 @@ func (t *OverviewRoute) devicesStreamMap() http.HandlerFunc {
 						log.Printf("cannot open writer for ws: %v\n", err)
 						return
 					}
-					defer writer.Close()
 					frame := fmt.Sprintf(`{"device_id": %d, "device_code": "%s", "coordinates": [%f,%f]}`, dev.Id, dev.Code, dev.GetLatitude(), dev.GetLongitude())
 					if _, err := writer.Write([]byte(frame)); err != nil {
 						log.Printf("Failed to write to websocket: %v\n", err)
 						return
 					}
+					writer.Close()
 				}
 				nextCursor = getCursor(res.Links.GetNext())
 				if nextCursor == "" {
@@ -369,10 +386,12 @@ func (t *OverviewRoute) overviewDatastreamStream() http.HandlerFunc {
 		start, err := time.Parse(time.RFC3339, r.URL.Query().Get("start"))
 		if err != nil {
 			web.HTTPError(w, web.NewError(http.StatusBadRequest, "Start parameter is not ISO8601/RFC3339", ""))
+			return
 		}
 		end, err := time.Parse(time.RFC3339, r.URL.Query().Get("end"))
 		if err != nil {
 			web.HTTPError(w, web.NewError(http.StatusBadRequest, "End parameter is not ISO8601/RFC3339", ""))
+			return
 		}
 
 		ws, err := upgrader.Upgrade(w, r, nil)

--- a/services/dashboard/routes/pipelines.go
+++ b/services/dashboard/routes/pipelines.go
@@ -240,34 +240,18 @@ func (h *PipelinePageHandler) updatePipeline(next http.Handler) http.Handler {
 
 		_, resp, err := h.coreClient.PipelinesApi.UpdatePipeline(r.Context(), pipelineId).UpdatePipelineRequest(updateDto).Execute()
 		if err != nil {
-			responseBody, err := io.ReadAll(resp.Body)
-			if err != nil {
-				log.Printf("in createPipeline, err reading response body: %s\n", err)
-			} else {
-				log.Printf("in createPipeline, err: %s\n", string(responseBody))
+			if resp != nil && resp.Body != nil {
+				if body, readErr := io.ReadAll(resp.Body); readErr == nil {
+					log.Printf("in updatePipeline, err: %s\n", string(body))
+				}
+			}
+			var apiErr *web.APIError
+			if errors.As(err, &apiErr) {
+				layout.WithSnackbarError(w, apiErr.Message)
+				w.WriteHeader(apiErr.HTTPStatus)
+				return
 			}
 			layout.SnackbarSomethingWentWrong(w)
-			return
-		}
-
-		// TODO: API returns status created instead of found for some reason
-		if resp.StatusCode != http.StatusCreated {
-			if resp.StatusCode == http.StatusInternalServerError {
-				responseBody, err := io.ReadAll(resp.Body)
-				if err != nil {
-					log.Printf("in createPipeline, err reading response body: %s\n", err)
-				} else {
-					log.Printf("in createPipeline, err: %s\n", string(responseBody))
-				}
-				layout.SnackbarSomethingWentWrong(w)
-			} else {
-				var apierror *web.APIError
-				if errors.As(err, &apierror) {
-					layout.WithSnackbarError(w, apierror.Message)
-					w.WriteHeader(apierror.HTTPStatus)
-					return
-				}
-			}
 			return
 		}
 
@@ -491,8 +475,6 @@ func (h *PipelinePageHandler) getWorkersForSteps(r *http.Request, steps []string
 	workers := res.GetData()
 	workers = append(workers, createPlaceholderWorkers(missingWorkers)...)
 
-	fmt.Printf("workers: %v\n", workers)
-	fmt.Printf("steps: %v\n", steps)
 	if len(workers) != len(steps) {
 		return nil, fmt.Errorf("some pipeline workers not found")
 	}

--- a/services/dashboard/routes/workers.go
+++ b/services/dashboard/routes/workers.go
@@ -56,7 +56,6 @@ func (h *WorkerPageHandler) listWorkers() http.HandlerFunc {
 			page.WorkersNextPage = views.U("/workers/table?cursor=%s", getCursor(res.Links.GetNext()))
 		}
 
-		fmt.Println("Cursor", res.Links.GetNext())
 		if isHX(r) {
 			page.WriteBody(w)
 			return
@@ -67,7 +66,6 @@ func (h *WorkerPageHandler) listWorkers() http.HandlerFunc {
 
 func (h *WorkerPageHandler) workersTable() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		fmt.Println("get table")
 		req := h.workersClient.WorkersApi.ListWorkers(r.Context())
 		if r.URL.Query().Has("cursor") {
 			req = req.Cursor(r.URL.Query().Get("cursor"))
@@ -129,9 +127,8 @@ func (h *WorkerPageHandler) updateWorker() http.HandlerFunc {
 		if name := r.FormValue("name"); name != "" {
 			dto.Name = &name
 		}
-		if desc := r.FormValue("description"); desc != "" {
-			dto.Description = &desc
-		}
+		desc := r.FormValue("description")
+		dto.Description = &desc
 		switch r.FormValue("state") {
 		case "on":
 			dto.SetState("enabled")
@@ -181,6 +178,12 @@ func (h *WorkerPageHandler) createWorker() http.HandlerFunc {
 		dto.SetName(r.FormValue("name"))
 		dto.SetUserCode(r.FormValue("userCode"))
 		dto.SetDescription(r.FormValue("description"))
+		switch r.FormValue("state") {
+		case "on":
+			dto.SetState("enabled")
+		default:
+			dto.SetState("disabled")
+		}
 
 		_, _, err := h.workersClient.WorkersApi.CreateWorker(r.Context()).CreateUserWorkerRequest(dto).Execute()
 		if err != nil {

--- a/services/dashboard/views/pipelineEditPage.qtpl
+++ b/services/dashboard/views/pipelineEditPage.qtpl
@@ -84,7 +84,8 @@
             </div>
         </div>
     </template>
-    <div 
+    {% if p.Pipeline != nil %}
+    <div
         class="bg-white border rounded-md lg:col-span-3 xl:col-span-3"
     >
         <header class="flex border-b py-2 px-4 text-sm text-slate-700">
@@ -94,6 +95,7 @@
         <div>
         </div>
     </div>
+    {% endif %}
 </div>
 {% endfunc %}
 

--- a/services/dashboard/views/pipelineEditPage.qtpl.go
+++ b/services/dashboard/views/pipelineEditPage.qtpl.go
@@ -181,60 +181,70 @@ func (p *PipelineEditPage) StreamBody(qw422016 *qt422016.Writer) {
             </div>
         </div>
     </template>
-    <div 
+    `)
+//line views/pipelineEditPage.qtpl:87
+	if p.Pipeline != nil {
+//line views/pipelineEditPage.qtpl:87
+		qw422016.N().S(`
+    <div
         class="bg-white border rounded-md lg:col-span-3 xl:col-span-3"
     >
         <header class="flex border-b py-2 px-4 text-sm text-slate-700">
           <span class="flex-1">Incoming data and processing statusses</span>
           <button hx-get="`)
-//line views/pipelineEditPage.qtpl:92
-	qw422016.E().S(U("/traces/list?pipeline=%s&limit=%d", p.Pipeline.Id, 10))
-//line views/pipelineEditPage.qtpl:92
-	qw422016.N().S(`" hx-trigger="load, click" hx-target="next div">Refresh</button>
+//line views/pipelineEditPage.qtpl:93
+		qw422016.E().S(U("/traces/list?pipeline=%s&limit=%d", p.Pipeline.Id, 10))
+//line views/pipelineEditPage.qtpl:93
+		qw422016.N().S(`" hx-trigger="load, click" hx-target="next div">Refresh</button>
         </header>
         <div>
         </div>
     </div>
+    `)
+//line views/pipelineEditPage.qtpl:98
+	}
+//line views/pipelineEditPage.qtpl:98
+	qw422016.N().S(`
 </div>
 `)
-//line views/pipelineEditPage.qtpl:98
+//line views/pipelineEditPage.qtpl:100
 }
 
-//line views/pipelineEditPage.qtpl:98
+//line views/pipelineEditPage.qtpl:100
 func (p *PipelineEditPage) WriteBody(qq422016 qtio422016.Writer) {
-//line views/pipelineEditPage.qtpl:98
+//line views/pipelineEditPage.qtpl:100
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line views/pipelineEditPage.qtpl:98
+//line views/pipelineEditPage.qtpl:100
 	p.StreamBody(qw422016)
-//line views/pipelineEditPage.qtpl:98
+//line views/pipelineEditPage.qtpl:100
 	qt422016.ReleaseWriter(qw422016)
-//line views/pipelineEditPage.qtpl:98
+//line views/pipelineEditPage.qtpl:100
 }
 
-//line views/pipelineEditPage.qtpl:98
+//line views/pipelineEditPage.qtpl:100
 func (p *PipelineEditPage) Body() string {
-//line views/pipelineEditPage.qtpl:98
+//line views/pipelineEditPage.qtpl:100
 	qb422016 := qt422016.AcquireByteBuffer()
-//line views/pipelineEditPage.qtpl:98
+//line views/pipelineEditPage.qtpl:100
 	p.WriteBody(qb422016)
-//line views/pipelineEditPage.qtpl:98
+//line views/pipelineEditPage.qtpl:100
 	qs422016 := string(qb422016.B)
-//line views/pipelineEditPage.qtpl:98
+//line views/pipelineEditPage.qtpl:100
 	qt422016.ReleaseByteBuffer(qb422016)
-//line views/pipelineEditPage.qtpl:98
+//line views/pipelineEditPage.qtpl:100
 	return qs422016
-//line views/pipelineEditPage.qtpl:98
+//line views/pipelineEditPage.qtpl:100
 }
 
-//line views/pipelineEditPage.qtpl:100
+//line views/pipelineEditPage.qtpl:102
 func (p *PipelineEditPage) StreamRenderPipelineSteps(qw422016 *qt422016.Writer, pipeline *api.Pipeline, workers *[]api.UserWorker) {
-//line views/pipelineEditPage.qtpl:100
+//line views/pipelineEditPage.qtpl:102
 	qw422016.N().S(`
     <script type="module">
         import '`)
-//line views/pipelineEditPage.qtpl:102
+//line views/pipelineEditPage.qtpl:104
 	qw422016.E().S(U("/static/sortable.js"))
-//line views/pipelineEditPage.qtpl:102
+//line views/pipelineEditPage.qtpl:104
 	qw422016.N().S(`';
         htmx.onLoad(function(content) {
             // Make the steps list sortable
@@ -334,201 +344,201 @@ func (p *PipelineEditPage) StreamRenderPipelineSteps(qw422016 *qt422016.Writer, 
     </div>
     <form id="sortableForm" name="sortable" class="sortable" hx-indicator="#stepsIndicator" hx-vals="js:{steps: getSteps()}"
         `)
-//line views/pipelineEditPage.qtpl:200
+//line views/pipelineEditPage.qtpl:202
 	if pipeline == nil {
-//line views/pipelineEditPage.qtpl:200
+//line views/pipelineEditPage.qtpl:202
 		qw422016.N().S(`
             hx-patch="`)
-//line views/pipelineEditPage.qtpl:201
+//line views/pipelineEditPage.qtpl:203
 		qw422016.E().S(U("/pipelines/validate"))
-//line views/pipelineEditPage.qtpl:201
+//line views/pipelineEditPage.qtpl:203
 		qw422016.N().S(`" hx-trigger="form-updated"
         `)
-//line views/pipelineEditPage.qtpl:202
+//line views/pipelineEditPage.qtpl:204
 	}
-//line views/pipelineEditPage.qtpl:202
+//line views/pipelineEditPage.qtpl:204
 	qw422016.N().S(`>
         `)
-//line views/pipelineEditPage.qtpl:203
+//line views/pipelineEditPage.qtpl:205
 	if workers != nil {
-//line views/pipelineEditPage.qtpl:203
+//line views/pipelineEditPage.qtpl:205
 		qw422016.N().S(`
             `)
-//line views/pipelineEditPage.qtpl:204
+//line views/pipelineEditPage.qtpl:206
 		StreamRenderPipelineStepsSortable(qw422016, p.CSRFToken, *workers)
-//line views/pipelineEditPage.qtpl:204
+//line views/pipelineEditPage.qtpl:206
 		qw422016.N().S(`
         `)
-//line views/pipelineEditPage.qtpl:205
+//line views/pipelineEditPage.qtpl:207
 	} else {
-//line views/pipelineEditPage.qtpl:205
+//line views/pipelineEditPage.qtpl:207
 		qw422016.N().S(`
             `)
-//line views/pipelineEditPage.qtpl:206
+//line views/pipelineEditPage.qtpl:208
 		p.streamrenderCSRFToken(qw422016)
-//line views/pipelineEditPage.qtpl:206
+//line views/pipelineEditPage.qtpl:208
 		qw422016.N().S(`
         `)
-//line views/pipelineEditPage.qtpl:207
+//line views/pipelineEditPage.qtpl:209
 	}
-//line views/pipelineEditPage.qtpl:207
+//line views/pipelineEditPage.qtpl:209
 	qw422016.N().S(`
     </form>
 `)
-//line views/pipelineEditPage.qtpl:209
+//line views/pipelineEditPage.qtpl:211
 }
 
-//line views/pipelineEditPage.qtpl:209
+//line views/pipelineEditPage.qtpl:211
 func (p *PipelineEditPage) WriteRenderPipelineSteps(qq422016 qtio422016.Writer, pipeline *api.Pipeline, workers *[]api.UserWorker) {
-//line views/pipelineEditPage.qtpl:209
+//line views/pipelineEditPage.qtpl:211
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line views/pipelineEditPage.qtpl:209
+//line views/pipelineEditPage.qtpl:211
 	p.StreamRenderPipelineSteps(qw422016, pipeline, workers)
-//line views/pipelineEditPage.qtpl:209
+//line views/pipelineEditPage.qtpl:211
 	qt422016.ReleaseWriter(qw422016)
-//line views/pipelineEditPage.qtpl:209
+//line views/pipelineEditPage.qtpl:211
 }
 
-//line views/pipelineEditPage.qtpl:209
+//line views/pipelineEditPage.qtpl:211
 func (p *PipelineEditPage) RenderPipelineSteps(pipeline *api.Pipeline, workers *[]api.UserWorker) string {
-//line views/pipelineEditPage.qtpl:209
+//line views/pipelineEditPage.qtpl:211
 	qb422016 := qt422016.AcquireByteBuffer()
-//line views/pipelineEditPage.qtpl:209
+//line views/pipelineEditPage.qtpl:211
 	p.WriteRenderPipelineSteps(qb422016, pipeline, workers)
-//line views/pipelineEditPage.qtpl:209
+//line views/pipelineEditPage.qtpl:211
 	qs422016 := string(qb422016.B)
-//line views/pipelineEditPage.qtpl:209
+//line views/pipelineEditPage.qtpl:211
 	qt422016.ReleaseByteBuffer(qb422016)
-//line views/pipelineEditPage.qtpl:209
+//line views/pipelineEditPage.qtpl:211
 	return qs422016
-//line views/pipelineEditPage.qtpl:209
+//line views/pipelineEditPage.qtpl:211
 }
 
-//line views/pipelineEditPage.qtpl:211
+//line views/pipelineEditPage.qtpl:213
 func StreamRenderPipelineStepsSortable(qw422016 *qt422016.Writer, csrfToken string, steps []api.UserWorker) {
-//line views/pipelineEditPage.qtpl:211
+//line views/pipelineEditPage.qtpl:213
 	qw422016.N().S(`
     `)
-//line views/pipelineEditPage.qtpl:212
+//line views/pipelineEditPage.qtpl:214
 	streamrenderCSRFToken(qw422016, csrfToken)
-//line views/pipelineEditPage.qtpl:212
+//line views/pipelineEditPage.qtpl:214
 	qw422016.N().S(`
     `)
-//line views/pipelineEditPage.qtpl:213
+//line views/pipelineEditPage.qtpl:215
 	for ix, step := range steps {
-//line views/pipelineEditPage.qtpl:213
+//line views/pipelineEditPage.qtpl:215
 		qw422016.N().S(`
         <div id="sortable-item-`)
-//line views/pipelineEditPage.qtpl:214
+//line views/pipelineEditPage.qtpl:216
 		qw422016.E().S(step.Id)
-//line views/pipelineEditPage.qtpl:214
+//line views/pipelineEditPage.qtpl:216
 		qw422016.N().S(`" class="p-2 w-2/4 mt-1.5 mx-auto text-white bg-secondary-600 rounded-lg flex justify-between items-center">
             <input type="hidden" name="`)
-//line views/pipelineEditPage.qtpl:215
+//line views/pipelineEditPage.qtpl:217
 		qw422016.E().S(step.Id)
-//line views/pipelineEditPage.qtpl:215
+//line views/pipelineEditPage.qtpl:217
 		qw422016.N().S(`" value="`)
-//line views/pipelineEditPage.qtpl:215
+//line views/pipelineEditPage.qtpl:217
 		qw422016.N().D(ix)
-//line views/pipelineEditPage.qtpl:215
+//line views/pipelineEditPage.qtpl:217
 		qw422016.N().S(`" />
             <div>
                 <p class="text-lg">`)
-//line views/pipelineEditPage.qtpl:217
+//line views/pipelineEditPage.qtpl:219
 		qw422016.E().S(step.Name)
-//line views/pipelineEditPage.qtpl:217
+//line views/pipelineEditPage.qtpl:219
 		qw422016.N().S(` v`)
-//line views/pipelineEditPage.qtpl:217
+//line views/pipelineEditPage.qtpl:219
 		qw422016.E().V(step.Revision)
-//line views/pipelineEditPage.qtpl:217
+//line views/pipelineEditPage.qtpl:219
 		qw422016.N().S(`</p>
                 <p class="text-sm font-thin">`)
-//line views/pipelineEditPage.qtpl:218
+//line views/pipelineEditPage.qtpl:220
 		qw422016.E().S(step.Description)
-//line views/pipelineEditPage.qtpl:218
+//line views/pipelineEditPage.qtpl:220
 		qw422016.N().S(`</p>
             </div>
             <div class="cursor-pointer w-10 p-2" onclick="removeFromSortable('`)
-//line views/pipelineEditPage.qtpl:220
+//line views/pipelineEditPage.qtpl:222
 		qw422016.E().S(step.Id)
-//line views/pipelineEditPage.qtpl:220
+//line views/pipelineEditPage.qtpl:222
 		qw422016.N().S(`')">
                 <iconify-icon icon="basil:trash-solid" width="100%" height="100%" class="text-white"></iconify-icon>
             </div>
         </div>
     `)
-//line views/pipelineEditPage.qtpl:224
+//line views/pipelineEditPage.qtpl:226
 	}
-//line views/pipelineEditPage.qtpl:224
+//line views/pipelineEditPage.qtpl:226
 	qw422016.N().S(`
 `)
-//line views/pipelineEditPage.qtpl:225
+//line views/pipelineEditPage.qtpl:227
 }
 
-//line views/pipelineEditPage.qtpl:225
+//line views/pipelineEditPage.qtpl:227
 func WriteRenderPipelineStepsSortable(qq422016 qtio422016.Writer, csrfToken string, steps []api.UserWorker) {
-//line views/pipelineEditPage.qtpl:225
+//line views/pipelineEditPage.qtpl:227
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line views/pipelineEditPage.qtpl:225
+//line views/pipelineEditPage.qtpl:227
 	StreamRenderPipelineStepsSortable(qw422016, csrfToken, steps)
-//line views/pipelineEditPage.qtpl:225
+//line views/pipelineEditPage.qtpl:227
 	qt422016.ReleaseWriter(qw422016)
-//line views/pipelineEditPage.qtpl:225
+//line views/pipelineEditPage.qtpl:227
 }
 
-//line views/pipelineEditPage.qtpl:225
+//line views/pipelineEditPage.qtpl:227
 func RenderPipelineStepsSortable(csrfToken string, steps []api.UserWorker) string {
-//line views/pipelineEditPage.qtpl:225
+//line views/pipelineEditPage.qtpl:227
 	qb422016 := qt422016.AcquireByteBuffer()
-//line views/pipelineEditPage.qtpl:225
+//line views/pipelineEditPage.qtpl:227
 	WriteRenderPipelineStepsSortable(qb422016, csrfToken, steps)
-//line views/pipelineEditPage.qtpl:225
+//line views/pipelineEditPage.qtpl:227
 	qs422016 := string(qb422016.B)
-//line views/pipelineEditPage.qtpl:225
+//line views/pipelineEditPage.qtpl:227
 	qt422016.ReleaseByteBuffer(qb422016)
-//line views/pipelineEditPage.qtpl:225
+//line views/pipelineEditPage.qtpl:227
 	return qs422016
-//line views/pipelineEditPage.qtpl:225
+//line views/pipelineEditPage.qtpl:227
 }
 
-//line views/pipelineEditPage.qtpl:227
+//line views/pipelineEditPage.qtpl:229
 func StreamRenderPipelineDetailEditor(qw422016 *qt422016.Writer) {
-//line views/pipelineEditPage.qtpl:227
+//line views/pipelineEditPage.qtpl:229
 	qw422016.N().S(`
  // TODO
 `)
-//line views/pipelineEditPage.qtpl:229
+//line views/pipelineEditPage.qtpl:231
 }
 
-//line views/pipelineEditPage.qtpl:229
+//line views/pipelineEditPage.qtpl:231
 func WriteRenderPipelineDetailEditor(qq422016 qtio422016.Writer) {
-//line views/pipelineEditPage.qtpl:229
+//line views/pipelineEditPage.qtpl:231
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line views/pipelineEditPage.qtpl:229
+//line views/pipelineEditPage.qtpl:231
 	StreamRenderPipelineDetailEditor(qw422016)
-//line views/pipelineEditPage.qtpl:229
+//line views/pipelineEditPage.qtpl:231
 	qt422016.ReleaseWriter(qw422016)
-//line views/pipelineEditPage.qtpl:229
+//line views/pipelineEditPage.qtpl:231
 }
 
-//line views/pipelineEditPage.qtpl:229
+//line views/pipelineEditPage.qtpl:231
 func RenderPipelineDetailEditor() string {
-//line views/pipelineEditPage.qtpl:229
+//line views/pipelineEditPage.qtpl:231
 	qb422016 := qt422016.AcquireByteBuffer()
-//line views/pipelineEditPage.qtpl:229
+//line views/pipelineEditPage.qtpl:231
 	WriteRenderPipelineDetailEditor(qb422016)
-//line views/pipelineEditPage.qtpl:229
+//line views/pipelineEditPage.qtpl:231
 	qs422016 := string(qb422016.B)
-//line views/pipelineEditPage.qtpl:229
+//line views/pipelineEditPage.qtpl:231
 	qt422016.ReleaseByteBuffer(qb422016)
-//line views/pipelineEditPage.qtpl:229
+//line views/pipelineEditPage.qtpl:231
 	return qs422016
-//line views/pipelineEditPage.qtpl:229
+//line views/pipelineEditPage.qtpl:231
 }
 
-//line views/pipelineEditPage.qtpl:231
+//line views/pipelineEditPage.qtpl:233
 func StreamRenderPipelineEditWorkerTable(qw422016 *qt422016.Writer, workers []api.UserWorker, nextPage string) {
-//line views/pipelineEditPage.qtpl:231
+//line views/pipelineEditPage.qtpl:233
 	qw422016.N().S(`
     <table class="w-full text-sm border-separate border-spacing-0" id="device-table">
         <thead class="text-left text-slate-500 sticky top-0 bg-white">
@@ -555,110 +565,110 @@ func StreamRenderPipelineEditWorkerTable(qw422016 *qt422016.Writer, workers []ap
         </thead>
         <tbody>
             `)
-//line views/pipelineEditPage.qtpl:256
+//line views/pipelineEditPage.qtpl:258
 	StreamRenderPipelineEditWorkerTableRows(qw422016, workers, nextPage)
-//line views/pipelineEditPage.qtpl:256
+//line views/pipelineEditPage.qtpl:258
 	qw422016.N().S(`
         </tbody>
     </table>
 `)
-//line views/pipelineEditPage.qtpl:259
+//line views/pipelineEditPage.qtpl:261
 }
 
-//line views/pipelineEditPage.qtpl:259
+//line views/pipelineEditPage.qtpl:261
 func WriteRenderPipelineEditWorkerTable(qq422016 qtio422016.Writer, workers []api.UserWorker, nextPage string) {
-//line views/pipelineEditPage.qtpl:259
+//line views/pipelineEditPage.qtpl:261
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line views/pipelineEditPage.qtpl:259
+//line views/pipelineEditPage.qtpl:261
 	StreamRenderPipelineEditWorkerTable(qw422016, workers, nextPage)
-//line views/pipelineEditPage.qtpl:259
+//line views/pipelineEditPage.qtpl:261
 	qt422016.ReleaseWriter(qw422016)
-//line views/pipelineEditPage.qtpl:259
+//line views/pipelineEditPage.qtpl:261
 }
 
-//line views/pipelineEditPage.qtpl:259
+//line views/pipelineEditPage.qtpl:261
 func RenderPipelineEditWorkerTable(workers []api.UserWorker, nextPage string) string {
-//line views/pipelineEditPage.qtpl:259
+//line views/pipelineEditPage.qtpl:261
 	qb422016 := qt422016.AcquireByteBuffer()
-//line views/pipelineEditPage.qtpl:259
+//line views/pipelineEditPage.qtpl:261
 	WriteRenderPipelineEditWorkerTable(qb422016, workers, nextPage)
-//line views/pipelineEditPage.qtpl:259
+//line views/pipelineEditPage.qtpl:261
 	qs422016 := string(qb422016.B)
-//line views/pipelineEditPage.qtpl:259
+//line views/pipelineEditPage.qtpl:261
 	qt422016.ReleaseByteBuffer(qb422016)
-//line views/pipelineEditPage.qtpl:259
+//line views/pipelineEditPage.qtpl:261
 	return qs422016
-//line views/pipelineEditPage.qtpl:259
+//line views/pipelineEditPage.qtpl:261
 }
 
-//line views/pipelineEditPage.qtpl:261
+//line views/pipelineEditPage.qtpl:263
 func StreamRenderPipelineEditWorkerTableRows(qw422016 *qt422016.Writer, workers []api.UserWorker, nextPage string) {
-//line views/pipelineEditPage.qtpl:261
+//line views/pipelineEditPage.qtpl:263
 	qw422016.N().S(`
     `)
-//line views/pipelineEditPage.qtpl:262
+//line views/pipelineEditPage.qtpl:264
 	for ix, worker := range workers {
-//line views/pipelineEditPage.qtpl:262
+//line views/pipelineEditPage.qtpl:264
 		qw422016.N().S(`
     <tr
         class="hover:bg-slate-50 group"
         `)
-//line views/pipelineEditPage.qtpl:265
+//line views/pipelineEditPage.qtpl:267
 		if nextPage != "" && ix == len(workers)-1 {
-//line views/pipelineEditPage.qtpl:265
+//line views/pipelineEditPage.qtpl:267
 			qw422016.N().S(`
         hx-trigger="revealed"
         hx-target="this"
         hx-swap="afterend"
         hx-get="`)
-//line views/pipelineEditPage.qtpl:269
+//line views/pipelineEditPage.qtpl:271
 			qw422016.E().S(nextPage)
-//line views/pipelineEditPage.qtpl:269
+//line views/pipelineEditPage.qtpl:271
 			qw422016.N().S(`"
         `)
-//line views/pipelineEditPage.qtpl:270
+//line views/pipelineEditPage.qtpl:272
 		}
-//line views/pipelineEditPage.qtpl:270
+//line views/pipelineEditPage.qtpl:272
 		qw422016.N().S(`
     >
         <td class="border-b"><a
             class="flex items-center px-4 h-10 text-primary-700 group-hover:underline"
             href="`)
-//line views/pipelineEditPage.qtpl:274
+//line views/pipelineEditPage.qtpl:276
 		qw422016.E().S(U("/workers/%s", worker.Id))
-//line views/pipelineEditPage.qtpl:274
+//line views/pipelineEditPage.qtpl:276
 		qw422016.N().S(`"
             hx-target="main"
         >`)
-//line views/pipelineEditPage.qtpl:276
+//line views/pipelineEditPage.qtpl:278
 		qw422016.E().S(worker.Name)
-//line views/pipelineEditPage.qtpl:276
+//line views/pipelineEditPage.qtpl:278
 		qw422016.N().S(`</a></td>
         <td class="px-4 h-10 border-b">`)
-//line views/pipelineEditPage.qtpl:277
+//line views/pipelineEditPage.qtpl:279
 		qw422016.N().D(int(worker.Revision))
-//line views/pipelineEditPage.qtpl:277
+//line views/pipelineEditPage.qtpl:279
 		qw422016.N().S(`</td>
         <td class="px-4 h-10 border-b">`)
-//line views/pipelineEditPage.qtpl:278
+//line views/pipelineEditPage.qtpl:280
 		qw422016.E().S(worker.Id)
-//line views/pipelineEditPage.qtpl:278
+//line views/pipelineEditPage.qtpl:280
 		qw422016.N().S(`</td>
         <td class="px-4 h-10 border-b">`)
-//line views/pipelineEditPage.qtpl:279
+//line views/pipelineEditPage.qtpl:281
 		qw422016.E().S(worker.Description)
-//line views/pipelineEditPage.qtpl:279
+//line views/pipelineEditPage.qtpl:281
 		qw422016.N().S(`</td>
         <td class="px-4 h-10 border-b">Python</td>
         <td class="px-4 h-10 border-b">
             <button onclick="addSortable('`)
-//line views/pipelineEditPage.qtpl:282
+//line views/pipelineEditPage.qtpl:284
 		qw422016.E().S(worker.Name)
-//line views/pipelineEditPage.qtpl:282
+//line views/pipelineEditPage.qtpl:284
 		qw422016.N().S(`', '`)
-//line views/pipelineEditPage.qtpl:282
+//line views/pipelineEditPage.qtpl:284
 		qw422016.E().S(worker.Id)
-//line views/pipelineEditPage.qtpl:282
+//line views/pipelineEditPage.qtpl:284
 		qw422016.N().S(`')" class="text-xs bg-emerald-400 hover:bg-emerald-500 text-white border border-emerald-500 rounded px-2 py-1">
                 Add
             </button>              
@@ -666,41 +676,41 @@ func StreamRenderPipelineEditWorkerTableRows(qw422016 *qt422016.Writer, workers 
         <!-- opacity-50 cursor-not-allowed pointer-events-none  -->
     </tr>
     `)
-//line views/pipelineEditPage.qtpl:288
+//line views/pipelineEditPage.qtpl:290
 	}
-//line views/pipelineEditPage.qtpl:288
+//line views/pipelineEditPage.qtpl:290
 	qw422016.N().S(`
 `)
-//line views/pipelineEditPage.qtpl:289
+//line views/pipelineEditPage.qtpl:291
 }
 
-//line views/pipelineEditPage.qtpl:289
+//line views/pipelineEditPage.qtpl:291
 func WriteRenderPipelineEditWorkerTableRows(qq422016 qtio422016.Writer, workers []api.UserWorker, nextPage string) {
-//line views/pipelineEditPage.qtpl:289
+//line views/pipelineEditPage.qtpl:291
 	qw422016 := qt422016.AcquireWriter(qq422016)
-//line views/pipelineEditPage.qtpl:289
+//line views/pipelineEditPage.qtpl:291
 	StreamRenderPipelineEditWorkerTableRows(qw422016, workers, nextPage)
-//line views/pipelineEditPage.qtpl:289
+//line views/pipelineEditPage.qtpl:291
 	qt422016.ReleaseWriter(qw422016)
-//line views/pipelineEditPage.qtpl:289
+//line views/pipelineEditPage.qtpl:291
 }
 
-//line views/pipelineEditPage.qtpl:289
+//line views/pipelineEditPage.qtpl:291
 func RenderPipelineEditWorkerTableRows(workers []api.UserWorker, nextPage string) string {
-//line views/pipelineEditPage.qtpl:289
+//line views/pipelineEditPage.qtpl:291
 	qb422016 := qt422016.AcquireByteBuffer()
-//line views/pipelineEditPage.qtpl:289
+//line views/pipelineEditPage.qtpl:291
 	WriteRenderPipelineEditWorkerTableRows(qb422016, workers, nextPage)
-//line views/pipelineEditPage.qtpl:289
+//line views/pipelineEditPage.qtpl:291
 	qs422016 := string(qb422016.B)
-//line views/pipelineEditPage.qtpl:289
+//line views/pipelineEditPage.qtpl:291
 	qt422016.ReleaseByteBuffer(qb422016)
-//line views/pipelineEditPage.qtpl:289
+//line views/pipelineEditPage.qtpl:291
 	return qs422016
-//line views/pipelineEditPage.qtpl:289
+//line views/pipelineEditPage.qtpl:291
 }
 
-//line views/pipelineEditPage.qtpl:292
+//line views/pipelineEditPage.qtpl:294
 type PipelineEditPage struct {
 	BasePage
 	Pipeline          *api.Pipeline


### PR DESCRIPTION
Fixes a batch of bugs found during a review of the dashboard web app. Each fix was developed in an isolated worktree and merged together; the combined branch builds, vets, and is `gofmt`-clean.

## Fixes

**Critical**
- **Pipeline "Create" page crash** — the traces panel dereferenced `p.Pipeline.Id` unconditionally; on `/pipelines/create` `Pipeline` is `nil`, panicking mid-render. The panel is now guarded with `{% if p.Pipeline != nil %}`. (`views/pipelineEditPage.qtpl`)

**High**
- **Device list pagination dropped the sensor-group filter** — `createSensorGroup`/`deleteSensorGroup` passed a bare cursor where a URL was expected (breaking infinite scroll), and `getDevicesTable`/`deviceListPage` omitted `sensor_group` from the next-page URL (page 2+ returned all devices). All four spots now build full `…?sensor_group=&cursor=` URLs (delete correctly omits the filter). (`routes/overview.go`)
- **Datastream websocket missing `return`s** — bad `start`/`end` params wrote an HTTP error then still tried to upgrade the socket on a committed response. Added `return` after each parse error. (`routes/overview.go`)

**Medium**
- **`updatePipeline` error handling** — read `resp.Body` when `resp` could be `nil`, fell through to a nil-deref status check, and had an unreachable `errors.As` branch. Rewritten to be nil-safe and return after surfacing the error. (`routes/pipelines.go`)
- **Trace timeline panic** — `trace.WorkerTimes[j]` could index out of range when the API returns fewer times than workers. Added a bounds guard. (`routes/ingress.go`)
- **Worker description couldn't be cleared** — empty form values were skipped; description is now always sent. (`routes/workers.go`)
- **Create-worker ignored the Enabled toggle** — `createWorker` now reads `state` and sets it. (`routes/workers.go`)

**Low / robustness**
- Added `middleware.Recoverer` so handler/template panics return a clean 500 instead of dropping the connection. (`main.go`)
- Fixed `formatSince` copy ("About 1 hour ago" / "About 1 minute ago") and removed a duplicated branch. (`routes/ingress.go`)
- Closed websocket frame writers per-iteration instead of `defer`-ing in a loop. (`routes/overview.go`)
- Removed stray `fmt.Print*` debug statements. (`workers.go`, `pipelines.go`, `main.go`)

## Verification
`go build ./services/dashboard/...`, `go vet ./services/dashboard/...`, and `gofmt -l` all clean.

## Not included (cosmetic / larger calls)
Worker name field styled to look disabled but editable; empty `200` on non-HTMX table endpoints; external CDN dependencies; unescaped server data in inline `<script>` strings; dead `Trace.PipelineName`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)